### PR TITLE
Pass dispatcher to plugins and start once

### DIFF
--- a/src/pluginHandler.ts
+++ b/src/pluginHandler.ts
@@ -9,10 +9,10 @@ interface PluginHandler {
 const createPluginHandler = (): PluginHandler => {
   const plugins: WorkhorsePlugin[] = [];
   return {
-    startPlugins: (config: WorkhorseConfig) => {
+    startPlugins: (config: WorkhorseConfig, dispatcher: CommandDispatcher) => {
       config.plugins.forEach((plugin) => {
         try {
-          plugin.onStart();
+          plugin.onStart(dispatcher);
         } catch (e) {
           error(`Plugin ${plugin.name} failed to start: ${e}`);
         }

--- a/src/plugins/PauseWhenOffline.ts
+++ b/src/plugins/PauseWhenOffline.ts
@@ -1,4 +1,4 @@
-import { WorkhorsePlugin } from '@/types';
+import { WorkhorsePlugin, CommandDispatcher } from '@/types';
 import { Emitter, Actions } from '@events';
 import { debug } from '@/util/logging.ts';
 
@@ -11,7 +11,7 @@ class PauseWhenOffline implements WorkhorsePlugin {
     this.online = true;
   }
 
-  onStart = (): void => {
+  onStart = (_dispatcher: CommandDispatcher): void => {
     this.online = navigator.onLine;
     if (!this.online) {
       this.handleOffline();

--- a/src/plugins/TaskMonitor.ts
+++ b/src/plugins/TaskMonitor.ts
@@ -1,4 +1,4 @@
-import { WorkhorsePlugin, EventPayload } from '@/types';
+import { WorkhorsePlugin, EventPayload, CommandDispatcher } from '@/types';
 import { Emitter, Notifications } from '@events';
 import { Subscriptions } from '@/events/eventTypes.ts';
 import {debug} from "@/util/logging.ts";
@@ -28,7 +28,7 @@ class TaskMonitor implements WorkhorsePlugin {
     this.notify();
   };
 
-  onStart(): void {
+  onStart(_dispatcher: CommandDispatcher): void {
     debug(this.name, ' starting');
     Emitter.on(Notifications.Task.Added, this.add);
     Emitter.on(Notifications.Task.Success, this.remove);

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ interface CommandDispatcher {
 
 interface WorkhorsePlugin {
   name: string;
-  onStart(): void;
+  onStart(dispatcher: CommandDispatcher): void;
   onStop(): void;
 }
 

--- a/src/workhorse.ts
+++ b/src/workhorse.ts
@@ -41,7 +41,6 @@ const initialize = async (
   const dispatcher = createDispatcher(taskQueue, executorPool);
 
   const pluginHandler = createPluginHandler();
-  pluginHandler.startPlugins(config, dispatcher);
 
   const poller = async () => {
     await dispatcher.poll();


### PR DESCRIPTION
## Summary
- Start plugins only once after executors are running
- Pass dispatcher to each plugin's `onStart`
- Update built-in plugins to accept dispatcher

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a54dd3d1d4832a920ca91c5bb4c9b8